### PR TITLE
Use closeAll to close fluent logger and not get the same logger on next factory get

### DIFF
--- a/src/main/java/com/github/vinted/logback/fluentd/FluentdAppender.java
+++ b/src/main/java/com/github/vinted/logback/fluentd/FluentdAppender.java
@@ -33,7 +33,7 @@ public class FluentdAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             super.stop();
         } finally {
             if (fluentLogger != null) {
-                fluentLogger.close();
+                FluentLogger.closeAll();
             }
         }
     }


### PR DESCRIPTION
The issue seems to be this:
* appender `start` does `FluentLoggerFactory.getLogger(*args)`, factory memorises logger by constructing key out of `args` and storing in a map
* appender `stop` does `FluentLogger#stop` and it closes the logger, but the factory still has logger in the map
* next `start` does `.getLogger` again and gets the old logger back but it no longer works, it no longer has a `sender` instance in it

@raimondasv @ljank